### PR TITLE
Update esp_euskalherria.csv

### DIFF
--- a/regions/spain/esp_euskalherria.csv
+++ b/regions/spain/esp_euskalherria.csv
@@ -1,21 +1,34 @@
 country_abbr,country_name,region_code,region_name,cmpcode,acronym,party_orig,party_engl,year,mani_title
-ES,Spain,15,Euskal Herria,33902,EA,Eusko Alkartasuna,Basque Solidarity,2008,
-ES,Spain,15,Euskal Herria,33902,EA,Eusko Alkartasuna,Basque Solidarity,2011,EL MOMENTO DE DAR LO MEJOR
-ES,Spain,15,Euskal Herria,33909,EHB,Euskal Herria Bildu,Basque Country Unite,2012,
-ES,Spain,15,Euskal Herria,33103,EQ,EQUO,,2012,
-ES,Spain,15,Euskal Herria,33903,Eus,Euskadiko Ezkerra,,1986,Programa
-ES,Spain,15,Euskal Herria,33220,IU,Izquierda Unida,United Left,2012,100 Propuestas para uni Euskadi de izquierdas
-ES,Spain,15,Euskal Herria,33902,PNV,Partido Nacionalista Vasco,Basque Nationalist Party,2012,
+
 ES,Spain,15,Euskal Herria,33902,PNV,PARTIDO NACIONALISTA VASCO.,Basque Nationalist Party,1982,CONSIDERACIÓN PREVIA AL PROGRAMA ELECTORAL
 ES,Spain,15,Euskal Herria,33902,PNV,PARTIDO NACIONALISTA VASCO.,Basque Nationalist Party,1986,CORTES GENERALES 1986. PROGRAMA ELECTORAL
 ES,Spain,15,Euskal Herria,33902,PNV,PARTIDO NACIONALISTA VASCO.,Basque Nationalist Party,1989,PROGRAMA ELECTORAL CONGRESO Y SENADO 1989
 ES,Spain,15,Euskal Herria,33902,PNV,PARTIDO NACIONALISTA VASCO.,Basque Nationalist Party,1993,?
-ES,Spain,15,Euskal Herria,33902,PNV,PARTIDO NACIONALISTA VASCO.,Basque Nationalist Party,2008,"Yo vivo en euskadi. Tú, ¿dónde vives?"
+
 ES,Spain,15,Euskal Herria,33902,PNV,Partido Nacionalita Vasco/Euskadi Alberti Jetzale,Basque Nationalist Party,1996,‘Han eta hemen’
 ES,Spain,15,Euskal Herria,33902,PNV,Partido Nacionalita Vasco/Euskadi Alberti Jetzale,Basque Nationalist Party,2000,‘Decide tú’
 ES,Spain,15,Euskal Herria,33902,PNV,Partido Nacionalita Vasco/Euskadi Alberti Jetzale,Basque Nationalist Party,2004,Programa elecciones generales
 ES,Spain,15,Euskal Herria,33902,PNV,Partido Nacionalita Vasco/Euskadi Alberti Jetzale,Basque Nationalist Party,2008,Yo vivo en Euskadi
+ES,Spain,15,Euskal Herria,33902,PNV,PARTIDO NACIONALISTA VASCO.,Basque Nationalist Party,2008,"Yo vivo en euskadi. Tú, ¿dónde vives?"
+
+ES,Spain,15,Euskal Herria,33903,Eus,Euskadiko Ezkerra,,1986,Programa
+
+ES,Spain,15,Euskal Herria,33902,EA,Eusko Alkartasuna,Basque Solidarity,2008,
+ES,Spain,15,Euskal Herria,33902,EA,Eusko Alkartasuna,Basque Solidarity,2011,EL MOMENTO DE DAR LO MEJOR
+
+
+ES,Spain,15,Euskal Herria,33320,PSOE,Partido Socialista Obrero Español ,Spanish Socialist Workers’ Party,2005,Programa Electoral Autonómicas País Vasco 2005 - UNA EUSKADI DE TODOS Y PARA TODOS
+ES,Spain,15,Euskal Herria,33610,PP,Partido Popular,Popular Party,2005,Programa Electoral - Nuestro compromiso con todas los vascos
+
+ES,Spain,15,Euskal Herria,33320,PSOE,Partido Socialista Obrero Español ,Spanish Socialist Workers’ Party,2009,Programa Electoral Autonómicas 2009
+ES,Spain,15,Euskal Herria,33902,PNV,Partido Nacionalista Vasco,Basque Nationalist Party,2009,Ibarretxe - AHORA MÁS QUE NUNCA - PROGRAMA ELECTORAL 2009 - Más de 700 iniciativas a tu servicio
+
+ES,Spain,15,Euskal Herria,33909,EHB,Euskal Herria Bildu,Basque Country Unite,2012,Programa electoral
+ES,Spain,15,Euskal Herria,33103,EQ,EQUO,2012,Programa electoral
+ES,Spain,15,Euskal Herria,33220,IU,Izquierda Unida,United Left,2012,100 Propuestas para uni Euskadi de izquierdas
+ES,Spain,15,Euskal Herria,33902,PNV,Partido Nacionalista Vasco,Basque Nationalist Party,2012,Compromiso Euskadi Programa electoral 2012
 ES,Spain,15,Euskal Herria,33610,PP,Partido Popular,Popular Party,2012,Ahora más que nunca
 ES,Spain,15,Euskal Herria,33320,PSOE,Partido Socialista Obrero Español ,Spanish Socialist Workers’ Party,2012,Trabajar por lo importante
+ES,Spain,15,Euskal Herria,33992,UP,Union Progreso y Democracia,Union Progress and Democracy,2012,Programa Electoral
+
 ES,Spain,15,Euskal Herria,33613,UPN,Unión de Pueblo Navarro,Navarrese People's Union,2015,
-ES,Spain,15,Euskal Herria,33992,UP,Union Progreso y Democracia,Union Progress and Democracy,2012,


### PR DESCRIPTION
PARTIDO NACIONALISTA VASCO 1982,1986,1989,1993,1996,2000,2004,2008(2x) , sowie Euskadiko Ezkerra, Union de Pueblo Navarro 2015 und Eusko Alkartasuna 2008, 2011 nicht online, nicht in Cohify gefunden -wo liegen die?

Fehler bei Codierung 33902 für PNV und EA
-Jahr 2005,2009 und 2012 stimmt mit Polidoc überein, 2005 und 2009 habe ich ergänzt (ab Zeile 20)