### PR TITLE
Update AT.csv

### DIFF
--- a/nations/austria/AT.csv
+++ b/nations/austria/AT.csv
@@ -1,7 +1,6 @@
 country_abbr,country_name,cmpcode,acronym,party_orig,party_engl,year,mani_title
-AT,Austria,42422,BZÖ,Bündnis Zukunft Österreich ,,2008,Deinetwegen. Österreich
-AT,Austria,42422,BZÖ,,,2013,
-AT,Austria,0,COAL,,,2013,
+AT,Austria,42422,BZÖ,Bündnis Zukunft Österreich,Bündnis Zukunft Österreich,2006,Positionen für ein modernes, soziales, leistungsfähiges und sicheres Österreich. 10 Schwerpunkte der Liste Westenthaler – BZÖ
+AT,Austria,42422,BZÖ,Bündnis Zukunft Österreich,Bündnis Zukunft Österreich,2013,Die Moderne Mitte! Das BZÖ-Wirtschafts- und Sozialprogramm
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,1983,Die Wahlplattform 1983 der Freiheitlichen Partei 
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,1986,‘Unser Österreich. Jörg Haider. Ein Politiker der neuen Art.’
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,1990,Blaue Markierungen. Schwerpunkte Freiheitlicher Erneuerungspolitik für Österreich.
@@ -11,8 +10,8 @@ AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,1999,Da
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,2002,‘Wir gestalten Österreich’
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,2006,Wahlprogramm der Freiheitlichen Partei Österreichs
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,2008,Österreich im Wort
-AT,Austria,42420,FPÖ,,,2013,
-AT,Austria,42952,Fritz,Liste Fritz Dinkhauser ,Liste Fritz Dinkhauser ,2008,Die zentralen Themen sind gerechte Verteilung das Beenden der Seilschaften und eine Politik die den Menschen in den Mittelpunkt stellt und nicht die Mächtigen.
+AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,2013,FPÖ Wahlprogramm Österreich 2013
+AT,Austria,42952,Fritz,Liste Fritz Dinkhauser,Liste Fritz Dinkhauser,2008,Die zentralen Themen sind gerechte Verteilung das Beenden der Seilschaften und eine Politik die den Menschen in den Mittelpunkt stellt und nicht die Mächtigen.
 AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1986,Es wird Zeit etwas zu tun
 AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1990,Leitlinien Grüner Politik
 AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1994,‘Alpeninitiative für Österreich’
@@ -21,32 +20,33 @@ AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1999,Kompetent. En
 AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2002,Österreich braucht jetzt die Grünen
 AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2006,Zeit für Grün. Das grüne Programm.
 AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2008,Neu beginnen!
+AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2013 Saubere Umwelt. Saubere Politik.  
 AT,Austria,42220,KPÖ,Kommunistische Partei Österreichs,Austrian Communist Party,2013,Positionen der KPÖ zur Nationalratswahl 2013
 AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,1994,‘Die Politik des Liberalen Forums’
 AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,1995,Die Offensive Mitte - ‘Setzen Sie ein Zeichen!’
 AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,1999,Liberale Antworten
 AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,2002,Für ein modernes Österreich. Das liberale Zukunftsprogramm 2002.
 AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,2008,Fairness
-AT,Austria,42951,Mart,Bürgerliste Martin,Bürgerliste Martin,2008,"für Demokratie, Kontrolle, Gerechtigkeit"
-AT,Austria,42450,NEOS,Das Neue Österreich und Liberales Forum,,2013,
+AT,Austria,42951,Mart,Bürgerliste Martin,Bürgerliste Martin,2008,"Für Demokratie, Kontrolle, Gerechtigkeit"
+AT,Austria,42450,NEOS,Das Neue Österreich und Liberales Forum,Das Neue Österreich und Liberales Forum,2013,Pläne für ein Neues Österreich
 AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,1983,‘Mit uns. Damit es wieder aufwärts geht.’
 AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,2002,‘Das Österreich-Programm der Volkspartei’
-AT,Austria,42520,ÖVP,Österreichische Volkspartei ,Austrian People’s Party,1986,‘Österreich zuerst. Das Mock-Programm für eine Wende zum Besseren’
-AT,Austria,42520,ÖVP,Österreichische Volkspartei ,Austrian People’s Party,1990,"Den Aufschwung wählen! Mit uns ist er sicher. ÖVP. Mehr Zukunft, weniger Sozialismus"
-AT,Austria,42520,ÖVP,Österreichische Volkspartei ,Austrian People’s Party,1994,‘Die Erhard-Busek-Pläne für Österreich’
-AT,Austria,42520,ÖVP,Österreichische Volkspartei ,Austrian People’s Party,1995,‘Der Schüssel-Ditz-Kurs’
-AT,Austria,42520,ÖVP,Österreichische Volkspartei ,Austrian People’s Party,1999,‘Der Bessere Weg’
-AT,Austria,42520,ÖVP,Österreichische Volkspartei ,Austrian People’s Party,2006,Kursbuch Zukunft
-AT,Austria,42520,ÖVP,Österreichische Volkspartei ,Austrian People’s Party,2008,Neustart für Österreich
-AT,Austria,42520,ÖVP,,,2013,
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,1986,‘Österreich zuerst. Das Mock-Programm für eine Wende zum Besseren’
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,1990,‘Den Aufschwung wählen! Mit uns ist er sicher. ÖVP. Mehr Zukunft, weniger Sozialismus’
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,1994,‘Die Erhard-Busek-Pläne für Österreich’
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,1995,‘Der Schüssel-Ditz-Kurs’
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,1999,‘Der Bessere Weg’
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,2006,Kursbuch Zukunft
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,2008,Neustart für Österreich
+AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,2013,Zukunftsweisend Österreich 2018: Das Programm der ÖVP zur Nationalratswahl 2013.
+AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,1983,Wahlprogramm der SPÖ - Für Österreich und seine Menschen 
+AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,1986,Vor uns liegt das neue Österreich
 AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,1990,Das Österreich von morgen. 
 AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,1994,Es geht um viel. Es geht um Österreich
 AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,1995,Gewinnen. Für Österreich.
 AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,1999,Der richtige Weg für Österreich
 AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,2002,Faire Chancen für alle!
-AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,2008,No title
-AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs ,Austrian Social Democratic Party,1983,Wahlprogramm der SPÖ - Für Österreich und seine Menschen 
-AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs ,Austrian Social Democratic Party,1986,Vor uns liegt das neue Österreich
 AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs ,Austrian Social Democratic Party,2006,Den Wohlstand gerecht verteilen.
-AT,Austria,42320,SPÖ,,,2013,
-AT,Austria,42101,VGÖ,Vereinte Grüne Österreichs,United Green Austria,2013,SAUBERE UMWELT. SAUBERE POLITIK. Wahlprogramm der Grünen Nationalratswahl 2013
+AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,2008,Wahlmanifest der Sozialdemokratischen Partei Österreichs
+AT,Austria,42320,SPÖ,Sozialdemokratische Partei Österreichs,Austrian Social Democratic Party,2013,111 Projekte für Österreich. SPÖ-Wahlprogramm 2013
+AT,Austria,42001,,Österreichische Bundesregierung,Österreichische Bundesregierung,2013, Arbeitsprogramm der österreichischen Bundesregierung     

--- a/nations/austria/AT.csv
+++ b/nations/austria/AT.csv
@@ -12,21 +12,21 @@ AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,2006,Wa
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,2008,Österreich im Wort
 AT,Austria,42420,FPÖ,Freiheitliche Partei Österreichs,Freedom Movement,2013,FPÖ Wahlprogramm Österreich 2013
 AT,Austria,42952,Fritz,Liste Fritz Dinkhauser,Liste Fritz Dinkhauser,2008,Die zentralen Themen sind gerechte Verteilung das Beenden der Seilschaften und eine Politik die den Menschen in den Mittelpunkt stellt und nicht die Mächtigen.
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1986,Es wird Zeit etwas zu tun
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1990,Leitlinien Grüner Politik
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1994,‘Alpeninitiative für Österreich’
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1995,Jetzt Farbe bekennen
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,1999,Kompetent. Engagiert. Grüne Positionen für eine neue Politik
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2002,Österreich braucht jetzt die Grünen
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2006,Zeit für Grün. Das grüne Programm.
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2008,Neu beginnen!
-AT,Austria,42110,GA,Die Grüne Alternative ,Green Alternative,2013 Saubere Umwelt. Saubere Politik.  
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,1986,Es wird Zeit etwas zu tun
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,1990,Leitlinien Grüner Politik
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,1994,‘Alpeninitiative für Österreich’
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,1995,Jetzt Farbe bekennen
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,1999,Kompetent. Engagiert. Grüne Positionen für eine neue Politik
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,2002,Österreich braucht jetzt die Grünen
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,2006,Zeit für Grün. Das grüne Programm.
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,2008,Neu beginnen!
+AT,Austria,42110,GA,Die Grüne Alternative,Green Alternative,2013 Saubere Umwelt. Saubere Politik.  
 AT,Austria,42220,KPÖ,Kommunistische Partei Österreichs,Austrian Communist Party,2013,Positionen der KPÖ zur Nationalratswahl 2013
-AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,1994,‘Die Politik des Liberalen Forums’
-AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,1995,Die Offensive Mitte - ‘Setzen Sie ein Zeichen!’
-AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,1999,Liberale Antworten
-AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,2002,Für ein modernes Österreich. Das liberale Zukunftsprogramm 2002.
-AT,Austria,42421,LF,Liberales Forum ,Liberal Forum,2008,Fairness
+AT,Austria,42421,LF,Liberales Forum,Liberal Forum,1994,‘Die Politik des Liberalen Forums’
+AT,Austria,42421,LF,Liberales Forum,Liberal Forum,1995,Die Offensive Mitte - ‘Setzen Sie ein Zeichen!’
+AT,Austria,42421,LF,Liberales Forum,Liberal Forum,1999,Liberale Antworten
+AT,Austria,42421,LF,Liberales Forum,Liberal Forum,2002,Für ein modernes Österreich. Das liberale Zukunftsprogramm 2002.
+AT,Austria,42421,LF,Liberales Forum,Liberal Forum,2008,Fairness
 AT,Austria,42951,Mart,Bürgerliste Martin,Bürgerliste Martin,2008,"Für Demokratie, Kontrolle, Gerechtigkeit"
 AT,Austria,42450,NEOS,Das Neue Österreich und Liberales Forum,Das Neue Österreich und Liberales Forum,2013,Pläne für ein Neues Österreich
 AT,Austria,42520,ÖVP,Österreichische Volkspartei,Austrian People’s Party,1983,‘Mit uns. Damit es wieder aufwärts geht.’


### PR DESCRIPTION
Sollten wir nicht die Parteien aufsteigend nach deren cmpcode sortieren, um eine bessere Übersicht zu gewährleisten?

Bei dem Wahlprogramm der Grünen Alternative in 1999 ist noch ein falscher Titel auf polidoc.net 
Bei dem Wahlprogramm der SPÖ in 2008 muss noch der Titel auf polidoc.net ergänzt werden 
Wahlprogramm der VGÖ in 2013 nicht auf polidoc.net vorhanden 
Partei Acronym für Österreichische Bundesregierung muss noch hinzugefügt werden