### PR TITLE
Update SE.csv

### DIFF
--- a/nations/sweden/SE.csv
+++ b/nations/sweden/SE.csv
@@ -1,13 +1,12 @@
 country_abbr,country_name,cmpcode,acronym,party_orig,party_engl,year,mani_title
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,1982,Valmanifest
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,1985,‘Med centern för framtiden’
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,1988,Valprogram 1989-1991
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,1991,‘I hela folkets intresse’
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,1994,‘Inför 1994 års val’
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,1998,‘Nya mitten - tillsammans lyfter vi Sverige’
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,2002,‘Ta vara på Sveriges möjligheter. Lika villkor Valmanifest 2002’
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,2006,"För fler jobb, förnyad välfärd och god miljö"
-SE,Sweden,11810,CP ,Centerpartiet,Centre Party,2010,Framtiden tillhör dem som vågar
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,1982,Valmanifest
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,1985,‘Med centern för framtiden’
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,1988,Valprogram 1989-1991
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,1991,‘I hela folkets intresse’
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,1994,‘Inför 1994 års val’
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,1998,‘Nya mitten - tillsammans lyfter vi Sverige’
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,2002,‘Ta vara på Sveriges möjligheter. Lika villkor Valmanifest 2002’
+SE,Sweden,11810,CP,Centerpartiet,Centre Party,2006,"För fler jobb, förnyad välfärd och god miljö"
 SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,1982,‘For frihet och rättvisa’
 SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,1985,‘Ny kurs för Sverige’
 SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,1988,‘Det behövs både hjärta och hjärna i politiken. 
@@ -16,7 +15,7 @@ SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,1994,Liberal
 SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,1998,‘Mänskligare Sverige’
 SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,2002,‘Ett parti som vågar utmana’
 SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,2006,En socialliberal modell i globalesirengs tid
-SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,2010,Utmaningar efter valsegern
+SE,Sweden,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,2010,Folkpartiet liberalernas valmanifest 2010
 SE,Sweden,11520,KdS,Kristdemokratiska Samhällspartiet,Christian Democratic Community Party,1988,KRISTDEMOKRATERNAS VALMANIFEST
 SE,Sweden,11520,KdS,Kristdemokratiska Samhällspartiet,Christian Democratic Community Party,1991,‘För gemenskap och människovärde’ 
 SE,Sweden,11520,KdS,Kristdemokratiska Samhällspartiet,Christian Democratic Community Party,1994,‘För en medmänskligare politik’
@@ -28,9 +27,9 @@ SE,Sweden,11110,MP,Miljöpartiet de Gröna,Green Ecology Party,1988,Valmanifest
 SE,Sweden,11110,MP,Miljöpartiet de Gröna,Green Ecology Party,1991,Valmanifest ‘91
 SE,Sweden,11110,MP,Miljöpartiet de Gröna,Green Ecology Party,1994,Valmanifest
 SE,Sweden,11110,MP,Miljöpartiet de Gröna,Green Ecology Party,1998,Valmanifest 98
+SE,Sweden,11110,MP,Miljöpartiet de Gröna ,Green Ecology Party,2002,Grönt Valmanifest 2002
 SE,Sweden,11110,MP,Miljöpartiet de Gröna,Green Ecology Party,2006,Grön ideologi – ett krav på handling
 SE,Sweden,11110,MP,Miljöpartiet de Gröna,Green Ecology Party,2010,Framtiden är här
-SE,Sweden,11110,MP,Miljöpartiet de Gröna ,Green Ecology Party,2002,Grönt Valmanifest 2002
 SE,Sweden,11620,MSP,Moderata Samlingspartiet,Moderat Coalition Party,1982,‘Framtid i frihet’
 SE,Sweden,11620,MSP,Moderata Samlingspartiet,Moderat Coalition Party,1985,‘Framtid i frihet’
 SE,Sweden,11620,MSP,Moderata Samlingspartiet,Moderat Coalition Party,1988,‘Framtidens ideer’
@@ -41,8 +40,7 @@ SE,Sweden,11620,MSP,Moderata Samlingspartiet,Moderat Coalition Party,2002,‘Rö
 SE,Sweden,11620,MSP,Moderata Samlingspartiet,Moderat Coalition Party,2006,2006:års Valmanifest
 SE,Sweden,11620,MSP,Moderata Samlingspartiet,Moderat Coalition Party,2010,Jobbmanifestet
 SE,Sweden,11951,NyD,Ny Demokrati,New Democracy,1991,"Demokrati: från grekiskan, demo-folket, kratein-härska, styra: folkstyre. I eg. mening, den yttersta makten tillhör medborgarna i förening"
-SE,Sweden,11710,SD,Sverige Democraterna,Sweden Democrats,2006,Antaget vid riksårsmötet den 25 mars 2006.
-SE,Sweden,11710,SD,Sverige Democraterna,Sweden Democrats,2010,99 förslag för ett bättre Sverige
+SE,Sweden,11710,SD,Sverige Democraterna,Sweden Democrats,2006,No title
 SE,Sweden,11320,SdaP,Socialdemokratiska Arbetarepartiet,Social Democratic Labor Party,1982,‘Fred och arbete’ 
 SE,Sweden,11320,SdaP,Socialdemokratiska Arbetarepartiet,Social Democratic Labor Party,1985,‘En inbjudan till alla Väljare’
 SE,Sweden,11320,SdaP,Socialdemokratiska Arbetarepartiet,Social Democratic Labor Party,1988,Valmanifest


### PR DESCRIPTION
Sverige Democraterna (11710) ist als Partei falsch auf polidoc.net benannt. (ist zusammen geschrieben)