### PR TITLE
Update se_västmanlands.csv

### DIFF
--- a/regions/sweden/se_västmanlands.csv
+++ b/regions/sweden/se_västmanlands.csv
@@ -1,2 +1,9 @@
 country_abbr,country_name,region_code,region_name,cmpcode,acronym,party_orig,party_engl,year,mani_title
-SE,Sweden,20,V�stmansland l�n,,,,,,
+SE,Sweden,20,Västmansland län,11320,SdaP,Socialdemokratiska Arbetarepartiet,Social Democratic Labor Party,2006,Hälso- och sjukvårdspolitiskt program 2006 – 2010 Västmanland
+SE,Sweden,20,Västmansland län,11320,SdaP,Socialdemokratiska Arbetarepartiet,Social Democratic Labor Party,2010,No title
+SE,Sweden,20,Västmansland län,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,2006,Liberal politik för en mer tillgänglig och trygg hälso- och sjukvård i Landstinget Västmanland
+SE,Sweden,20,Västmansland län,11420,FP,Folkpartiet Liberalerna,Liberal People’s Party,2010,No title
+SE,Sweden,20,Västmansland län,11520,KdS,Kristdemokratiska Samhällspartiet,Christian Democratic Community Party,2006,Landstingsmanifest
+SE,Sweden,20,Västmansland län,11520,KdS,Kristdemokratiska Samhällspartiet,Christian Democratic Community Party,2010,Kristdemokraternas Landstingspolitiska princip- och handlingsprogram 2011-14
+SE,Sweden,20,Västmansland län,11810,CP,Centerpartiet,Centre Party,2006,Länsprogram 2006-2010
+SE,Sweden,20,Västmansland län,11810,CP,Centerpartiet,Centre Party,2010,MÖJLIGHETERNAMÖJLIGHETERNAS VÄSTMANLAND


### PR DESCRIPTION
Das Parteiprogramm von Vänsterpartiet in 2010 existiert nicht. Der Eintrag muss noch auf polidoc gelöscht werden.