### PR TITLE
Update de_bay.csv

### DIFF
--- a/regions/germany/de_bay.csv
+++ b/regions/germany/de_bay.csv
@@ -1,14 +1,40 @@
 country_abbr,country_name,region_code,region_name,cmpcode,acronym,party_orig,party_engl,year,mani_title
-DE,Deutschland,4,Bayern,41521,CDU,Christlich Demokratische Union,Christian Democratic Union,1978,Aktionsprogramm zur Landtagswahl 1978
-DE,Deutschland,4,Bayern,41521,CDU,Christlich Demokratische Union,Christian Democratic Union,1982,Programm der CSU für die Landtagswahl '82
-DE,Deutschland,4,Bayern,41521,CDU,Christlich Demokratische Union,Christian Democratic Union,1982,Kraftvoll in die Zukunft
-DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern ,Christian Social Union of Bavaria,2013,Der Bayernplan
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,1978,Aktionsprogramm zur Landtagswahl 1978
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,1982,Programm der CSU für die Landtagswahl '82
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,1982,Kraftvoll in die Zukunft
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,1986,Franz Josef Strauß für Bayern
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,1990,Programm zur Landtagswahl 1990. Deutschland kommt. Bayern bleibt stark. Mit uns. CSU
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,1994,Programm für Bayern
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,1998,Das Programm für Bayerns Zukunft
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,2003,Regierungsprogramm 2003 – 2008: Damit Bayern stark bleibt. CSU.
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,2008,Für ein starkes Bayern. Regierungsprogramm 2008 bis 2013
+DE,Deutschland,4,Bayern,41523,CSU,Christlich-Soziale Union in Bayern,Christian Social Union of Bavaria,2013,Der Bayernplan
+DE,Deutschland,4,Bayern,41223,LINKE,Die Linke,The left,2008,Bayern für alle. Wahlprogramm für bayerische Landtagswahl 2008
 DE,Deutschland,4,Bayern,41223,LINKE,Die Linke,The left,2013,Bayern - sozial und solidarisch
-DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei ,Free Democratic Party,1978,Landeswahlprogramm '78
-DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei ,Free Democratic Party,2013,Bayerns treibende Kraft.
-DE,Deutschland,4,Bayern,41440,FWG,Freie Wählergemeinschaft,Free Voters,2013,HEIMAT gemeinsam für die MENSCHEN gestalten
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,1978,Landeswahlprogramm '78
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,1986,Warum Bayerns Landtag die F.D.P. braucht
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,1990,Auf dem Weg in den Landtag
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,1994,Bayern braucht den Wandel. Landtagswahl ´94
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,1998,Wir machen Zukunft. Liberales Programm zur bayerischen Landtagswahl 1998
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,2003,gelb mobilisiert – Liberales Programm zur bayerischen Landtagswahl 2003. Die politischen Schwerpunkte der Bayerischen FDP
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,2008,Liberales Programm zur Landtagswahl 2008
+DE,Deutschland,4,Bayern,41420,FDP,Freie Demokratische Partei,Free Democratic Party,2013,Liberales Wahlprogramm zur bayerischen Landtagswahl 2013
+DE,Deutschland,4,Bayern,41440,FWG,Freie Wählergemeinschaft,Free Voters,2003,Kurzprogramm der Freien Wähler Bayern zur Landtags- und Bezirkstagswahl am 21. September 2003
+DE,Deutschland,4,Bayern,41440,FWG,Freie Wählergemeinschaft,Free Voters,2008,Zukunft sichern!
+DE,Deutschland,4,Bayern,41440,FWG,Freie Wählergemeinschaft,Free Voters,2013,Heimat gemeinsam für die Menschen gestalten
+DE,Deutschland,4,Bayern,41111,GRÜNE,Die Grünen,Die Grünen,1986,Das Programm für Bayern
+DE,Deutschland,4,Bayern,41113,GRÜNE,Bündnis90/Die Grünen,Alliance '90 / Die Grünen,1994,Landtagswahlprogramm ´94 Nur mit den Grünen WECHSEL IN BAYERN
+DE,Deutschland,4,Bayern,41113,GRÜNE,Bündnis90/Die Grünen,Alliance '90 / Die Grünen,1998,Landtagswahlprogramm ´98. „Ein Zukunftsplan für Bayern“
+DE,Deutschland,4,Bayern,41113,GRÜNE,Bündnis90/Die Grünen,Alliance '90 / Die Grünen,2003,Programm für die Landtagswahl in Bayern am 21.9.2003
+DE,Deutschland,4,Bayern,41113,GRÜNE,Bündnis90/Die Grünen,Alliance '90 / Die Grünen,2008,Unser Wahlprogramm 2008 – 2013
 DE,Deutschland,4,Bayern,41113,GRÜNE,Bündnis90/Die Grünen,Alliance '90 / Die Grünen,2013,"Bayern ist reif, und Du?"
 DE,Deutschland,4,Bayern,41950,Pirat,Piratenpartei Deutschland,Pirate Party Germany,2013,Wahlprogramm Bayern 2013
 DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,1978,Landtagswahlprogramm der Bayrischen SPD zur 9. Legislaturperiode
 DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,1982,Mit uns in Bayern für mehr Rechte und Verantwortung der Bürger
+DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,1986,Für die Rechte der Bürger - gegen schwarze Arroganz
+DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,1990,Bayern bewahren. Deutschland gestalten. Den Menschen dienen. Wahlplattform ´90
+DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,1994,Es ist Zeit für den Wechsel. Für ein soziales, ökologisches und demokratisches Bayern. Regierungsprogramm der BayernSPD 1994
+DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,1998,Brücken in Bayerns Zukunft – Arbeit, Gerechtigkeit, Bildung und Innovation – Regierungsprogramm der Bayern SPD
+DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,2003,Bayern gewinnt. Regierungsprogramm der BayernSPD 2003 – 2008
+DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,2008,Bayern, aber gerechter. Regierungsprogramm der BayernSPD 2008 – 2013
 DE,Deutschland,4,Bayern,41320,SPD,Sozialdemokratische Partei Deutschlands,Social Democratic Party of Germany,2013,Jetzt ist alles drin! Wir bringen Bayern ins Gleichgewicht.


### PR DESCRIPTION
Codierung der Grünen noch einmal überprüfen, da manchmal 41111 oder 41113 genutzt wird (auch keine klare Differenzierung zwischen Die Grünen und Bündnis90/Die Grünen)

Außerdem Parteiprogramm der SPD muss in 2013 auf polidoc noch in "Jetzt ist alles drin! Wir bringen Bayern ins Gleichgewicht." umgewandelt werden